### PR TITLE
[#17] feature: 채팅 메세지 전송(송수신) 기능 구현

### DIFF
--- a/chat-server/src/main/java/com/grm3355/zonie/chatserver/config/RedisConfig.java
+++ b/chat-server/src/main/java/com/grm3355/zonie/chatserver/config/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.grm3355.zonie.chatserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	// (1) MessageService에서 사용할 RedisTemplate<String, Object> Bean 등록
+	//     (Message 객체를 JSON으로 직렬화/역직렬화하기 위함)
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// Key는 String으로 직렬화
+		template.setKeySerializer(new StringRedisSerializer());
+
+		// Value는 JSON으로 직렬화 (GenericJackson2JsonRedisSerializer 사용)
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		// Hash Key/Value도 동일하게 설정 (필요시)
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		return template;
+	}
+
+	// (2) EchoHandler에서 사용하는 RedisTemplate<String, String> Bean 등록
+	//     (StringRedisTemplate Bean으로 이미 자동 등록되지만, 명시적으로 만듦)
+	@Bean
+	public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// Key/Value 모두 String으로 직렬화
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+
+		return template;
+	}
+}

--- a/chat-server/src/main/java/com/grm3355/zonie/chatserver/config/RedisSubscriberConfig.java
+++ b/chat-server/src/main/java/com/grm3355/zonie/chatserver/config/RedisSubscriberConfig.java
@@ -4,41 +4,87 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+import com.grm3355.zonie.commonlib.domain.message.Message;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class RedisSubscriberConfig {
 
 	private final SimpMessageSendingOperations messagingTemplate;
+	private final ObjectMapper objectMapper;
 
 	// (1) Redis의 메시지를 STOMP 브로커로 전송하는 실제 핸들러
 	public class RedisSubscriber {
-		public void handleMessage(String message) {
+		public void handleEcho(String message) {
 			System.out.println("LOG: Redis Pub/Sub received: " + message);
 			messagingTemplate.convertAndSend("/sub/echo", message); // 메시지를 받아서 STOMP 브로커(/sub/echo)로 브로드캐스팅
+		}
+		public void handleMessage(String messageJson, String channel) {
+			try {
+				// 1. JSON 파싱 (이중 포장 풀기)
+				String innerJson = objectMapper.readValue(messageJson, String.class);
+				Message message = objectMapper.readValue(innerJson, Message.class);
+
+				// --- 2. Message 객체에서 실제 roomId 가져오기 ---
+				String roomId = message.getChatRoomId(); // e.g., "my-local-room"
+				if (roomId == null || roomId.isEmpty()) {
+					log.error("Message에 chatRoomId가 없습니다!");
+					return;
+				}
+
+				// --- 3. STOMP 토픽 생성 ---
+				String stompTopic = "/sub/chat-rooms/" + roomId;
+				// (결과) "/sub/chat-rooms/my-local-room"
+				log.info(">>> REDIS SUB RECV [Channel: {}] -> [StompTopic: {}]", channel, stompTopic);
+
+				// 4. 해당 STOMP 토픽으로 메시지 브로드캐스팅
+				messagingTemplate.convertAndSend(stompTopic, message);
+
+			} catch (Exception e) {
+				log.error("RedisSubscriber handleMessage Error", e);
+			}
 		}
 	}
 
 	// (2) 메시지 리스너 어댑터: 실제 핸들러(RedisSubscriber)를 연결
+	// (2-A) 실제 채팅용 메시지 리스너 어댑터
 	@Bean
-	MessageListenerAdapter listenerAdapter() {
-		// RedisSubscriber의 handleMessage 메소드가 메시지를 처리하도록 설정
+	MessageListenerAdapter chatListenerAdapter() {
+		// RedisSubscriber의 "handleMessage" 메소드가 메시지를 처리하도록 설정
 		return new MessageListenerAdapter(new RedisSubscriber(), "handleMessage");
+	}
+
+	// (2-B) Echo 테스트용 메시지 리스너 어댑터
+	@Bean
+	MessageListenerAdapter echoListenerAdapter() {
+		// RedisSubscriber의 "handleEcho" 메소드가 메시지를 처리하도록 설정
+		return new MessageListenerAdapter(new RedisSubscriber(), "handleEcho");
 	}
 
 	// (3) Redis 메시지 리스너 컨테이너: 어떤 채널을 구독할지 설정
 	@Bean
-	RedisMessageListenerContainer redisContainer(RedisConnectionFactory connectionFactory, MessageListenerAdapter listenerAdapter) {
+	RedisMessageListenerContainer redisContainer(RedisConnectionFactory connectionFactory,
+		MessageListenerAdapter chatListenerAdapter,
+		MessageListenerAdapter echoListenerAdapter) {
+
 		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
 
-		// "echo-channel"이라는 토픽(채널)을 구독
-		container.addMessageListener(listenerAdapter, new ChannelTopic("echo-channel"));
+		// "chat-room:*" 패턴을 구독 (chatListenerAdapter 사용)
+		container.addMessageListener(chatListenerAdapter, new PatternTopic("chat-room:*"));
+
+		// "echo-channel" 토픽을 구독 (echoListenerAdapter 사용)
+		container.addMessageListener(echoListenerAdapter, new ChannelTopic("echo-channel"));
 
 		return container;
 	}

--- a/chat-server/src/main/java/com/grm3355/zonie/chatserver/config/WebSocketConfig.java
+++ b/chat-server/src/main/java/com/grm3355/zonie/chatserver/config/WebSocketConfig.java
@@ -24,10 +24,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		registry.setApplicationDestinationPrefixes("/app");
 
 		// server -> client 메세지 수신 (Sub) 엔드포인트: /sub
-		// 클라이언트가 "/sub/echo"를 구독하면, 서버는 이 주소로 메시지를 브로드캐스팅함
-		// - Spring Simple (in-memory) Message Broker 사용: RedisSubscriber가 Redis에서 받은 메세지를 이 브로커(/sub)로 쏴줌: 간단하지만 유실 가능성이 있고 모니터링이 어려움
-		// - Redis Pub/Sub: 지속성이 없지만 실시간성 데이터 처리에 적합.
-		// - Redis는 STOMP 지원하지 않지만, Pub/Sub 기능을 통해 메세지 브로커를 사용할 수 있음
+		// RedisSubscriber가 Redis(Pub/Sub)에서 받은 메시지를
+		// 이곳에 등록된 SimpleBroker(/sub)로 전송하여 클라이언트에게 브로드캐스팅함.
 		registry.enableSimpleBroker("/sub");
 
 	}

--- a/chat-server/src/main/java/com/grm3355/zonie/chatserver/controller/ChatRoomHandler.java
+++ b/chat-server/src/main/java/com/grm3355/zonie/chatserver/controller/ChatRoomHandler.java
@@ -1,0 +1,52 @@
+package com.grm3355.zonie.chatserver.controller;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Controller;
+
+import com.grm3355.zonie.chatserver.dto.MessageSendRequest;
+import com.grm3355.zonie.commonlib.domain.message.MessageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatRoomHandler {
+
+	// private final ChatRoomService chatRoomService; // (feature/15)
+	private final MessageService messageService;
+
+	// ... (@MessageMapping("/join"), @MessageMapping("/leave") ... )
+
+	/**
+	 * 채팅 메시지 전송 (Send)
+	 */
+	@MessageMapping("/chat-rooms/{roomId}/send")
+	public void sendMessage(
+		@DestinationVariable String roomId,
+		@Payload MessageSendRequest request,
+		// @AuthenticationPrincipal UserDetailsImpl user,
+		StompHeaderAccessor accessor
+	) {
+
+		String userId = request.getTempUserId();
+		String content = request.getContent();
+
+		// String userId = user.getUsername();
+
+		// 1. Location-Token 헤더 검증
+		// String locationToken = accessor.getFirstNativeHeader("Location-Token");
+		// locationService.validateToken(userId, locationToken); // (이 로직은 나중에 추가)
+
+		// STOMP 핸들러가 메시지를 받았는지 로그 확인
+		log.debug(">>> STOMP RECV /app/chat-rooms/{}/send [User: {}, Msg: {}]",
+			roomId, userId, content);
+
+		// 2. 메시지 저장 및 발행
+		messageService.sendMessage(userId, roomId, content);
+	}
+}

--- a/chat-server/src/main/java/com/grm3355/zonie/chatserver/controller/EchoHandler.java
+++ b/chat-server/src/main/java/com/grm3355/zonie/chatserver/controller/EchoHandler.java
@@ -1,11 +1,13 @@
-package com.grm3355.zonie.chatserver.websocket;
+package com.grm3355.zonie.chatserver.controller;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class EchoHandler {
@@ -20,7 +22,7 @@ public class EchoHandler {
 	 */
 	@MessageMapping("/echo")
 	public void echo(String message) {
-		System.out.println("LOG: /app/echo received: " + message);
+		log.info("LOG: /app/echo received: {}", message);
 		redisTemplate.convertAndSend("echo-channel", "[Echo] " + message); // StompBrokerRelay 대신 RedisTemplate으로 직접 Pub
 	}
 }

--- a/chat-server/src/main/java/com/grm3355/zonie/chatserver/dto/MessageSendRequest.java
+++ b/chat-server/src/main/java/com/grm3355/zonie/chatserver/dto/MessageSendRequest.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.chatserver.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MessageSendRequest {
+	private String content;
+	private String tempUserId; // (임시) 인증이 구현되기 전까지 사용할 ID
+	// (확장 기능: img)
+}

--- a/chat-server/src/main/resources/application.yml
+++ b/chat-server/src/main/resources/application.yml
@@ -13,6 +13,10 @@ spring:
       "dev": "dev,local"  # "dev" 프로필이 실행되면, "local"도 같이 읽어라!
       "prod": "prod"      # (AWS에서 prod로 실행되면, local은 안 읽음)
 
+  main:
+    # RedisConfig에서 stringRedisTemplate Bean을 덮어쓰는 것을 허용
+    allow-bean-definition-overriding: true
+
 server:
   # api-server(8080)와 로컬에서 충돌하지 않도록 포트를 다르게 설정합니다.
   port: 8081

--- a/common-lib/build.gradle
+++ b/common-lib/build.gradle
@@ -15,15 +15,15 @@ jar {
 
 dependencies {
     // 모듈별 의존성
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis' //redis
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
-    // PostGIS 의존성, PostgreSQL 드라이버 추가
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.hibernate.orm:hibernate-spatial:6.5.2.Final'
     implementation 'org.locationtech.jts:jts-core:1.19.0' // JTS Core Library
     runtimeOnly 'org.postgresql:postgresql'
 
-    implementation 'org.springframework.boot:spring-boot-starter-validation' //jpa 애노테이션
-    //implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9' //dto Schema 필요
-
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }

--- a/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/message/Message.java
+++ b/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/message/Message.java
@@ -1,0 +1,35 @@
+package com.grm3355.zonie.commonlib.domain.message;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor // Jackson이 객체 생성 시 필요
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // Builder가 사용
+@Document(collection = "messages") // MongoDB 컬렉션 이름
+public class Message {
+
+	@Id
+	private String id; // Mongo의 ObjectId
+	private String chatRoomId; // 어느 방의 메시지인지 (인덱싱 필요)
+	private String userId;       // 누가 보냈는지
+	private String nickname;     // (Join/Leave 기능 완성 후 채워넣을 필드)
+	private String content;      // 메시지 내용
+	private MessageType type;    // e.g., TEXT, IMAGE
+	private LocalDateTime createdAt;
+
+	// (확장 기능: 좋아요)
+	// private Integer likeCount;
+	// private Set<String> likedByUserIds;
+}

--- a/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/message/MessageRepository.java
+++ b/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/message/MessageRepository.java
@@ -1,0 +1,10 @@
+package com.grm3355.zonie.commonlib.domain.message;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MessageRepository extends MongoRepository<Message, String> {
+	// (확장 기능: 과거 메시지 조회 - api-server용)
+	// Page<Message> findByChatRoomIdOrderByCreatedAtDesc(String chatRoomId, Pageable pageable);
+}

--- a/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/message/MessageService.java
+++ b/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/message/MessageService.java
@@ -1,0 +1,62 @@
+package com.grm3355.zonie.commonlib.domain.message;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+	private final MessageRepository messageRepository;
+	private final RedisTemplate<String, Object> redisTemplate; // (Pub/Sub용)
+	private final ObjectMapper objectMapper;
+
+	// (PR #12 머지 후 주입받아야 함)
+	// private final ChatRoomUserRepository chatRoomUserRepository;
+
+	public void sendMessage(String userId, String roomId, String content) {
+
+		// 1. (차단됨) 닉네임 가져오기
+		// TODO: PR #12 머지 후, chatRoomUserRepository에서 닉네임 조회 로직 추가
+		// User user = ...; ChatRoom room = ...;
+		// String nickname = chatRoomUserRepository.findByUserAndChatRoom(user, room)
+		//         .map(ChatRoomUser::getNickname)
+		//         .orElse("Unknown");
+		String nickname = "임시 닉네임"; // (임시 하드코딩)
+
+		// 2. MongoDB에 메시지 즉시 저장 (R&R 1번)
+		Message message = Message.builder()
+			.chatRoomId(roomId)
+			.userId(userId)
+			.nickname(nickname)
+			.content(content)
+			.type(MessageType.TEXT)
+			.createdAt(LocalDateTime.now())
+			.build();
+		messageRepository.save(message);
+
+		// 3. Redis Pub/Sub으로 다른 서버에 전파
+		// (채팅방 구독자들에게 브로드캐스팅)
+		try {
+			// 객체를 JSON 문자열로 직렬화하여 Publish
+			String messageJson = objectMapper.writeValueAsString(message);
+			redisTemplate.convertAndSend("chat-room:" + roomId, messageJson);
+		} catch (JsonProcessingException e) {
+			log.error("Message 직렬화 실패", e);
+		}
+
+		// 4. Redis에 마지막 대화 시각 갱신
+		redisTemplate.opsForValue().set("chatroom:last_msg_at:" + roomId, String.valueOf(System.currentTimeMillis()));
+		// (확장 기능: 마지막 메시지 내용 갱신)
+		// redisTemplate.opsForValue().set("chatroom:last_msg_content:" + roomId, content);
+	}
+}

--- a/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/message/MessageType.java
+++ b/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/message/MessageType.java
@@ -1,0 +1,5 @@
+package com.grm3355.zonie.commonlib.domain.message;
+
+public enum MessageType {
+	TEXT, IMAGE, SYSTEM
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
 services:
   # --- 1. Database (PostgreSQL) ---
   postgres_db:
-    image: postgis/postgis:16-3.4 #PostGIS 포함 이미지 사용
+    image: postgis/postgis:16-3.4
     container_name: zonie_postgres_db
     ports:
       - "5432:5432"


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: #6
- 서브 이슈: Resolved: #17 

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
1. [WS & STOMP] 웹소켓 연결 엔드포인트(WebSocketConfig.java) 설정 및 /app, /sub 브로커 프리픽스 설정
2. [메시지 전송] ChatRoomHandler에 /chat-rooms/{roomId}/send 엔드포인트 구현
    - MessageSendRequest DTO를 사용해 메시지 Payload 수신
    - 현재는 임시 사용자 ID(tempUserId) 사용
3. [메시지 저장 & 발행] MessageService에 메시지 저장 및 발행 로직 구현
    - 메시지를 Message 객체로 변환 후, MongoDB (MessageRepository)에 저장하여 영속성 확보
    - 저장된 Message 객체를 Redis Pub/Sub 채널 (chat-room:{roomId})로 발행하여 스케일 아웃 지원
4. [메시지 수신 & 브로드캐스팅] RedisSubscriberConfig에 메시지 수신 로직 구현
    - Redis에서 이중 직렬화된 메시지(Double-Serialized JSON String)를 정상적으로 역직렬화하도록 처리
    - 수신된 메시지를 구독 토픽(/sub/chat-rooms/{roomId})으로 브로드캐스팅하여 클라이언트에게 전송

## 변경 이유
> 왜 이 변경이 필요한지 설명
- 실시간 메시지 전송 및 저장 파이프라인을 구축하기 위함
- Redis Pub/Sub을 도입하여 서버가 다중 인스턴스로 확장되어도 메시지 유실 없이 모든 클라이언트에게 실시간으로 전송되도록 시스템 기반을 마련

## 테스트
> 어떤 방법으로 검증했는지 작성
- 서버 로그 확인 완료
- MongoDB 확인 완료
- WebSocket Debug Tool을 사용하여 클라이언트 2개를 연결하고 검증 완료

## 참고 자료 (선택)
- [WebSocket Debug Tool](https://jiangxy.github.io/websocket-debug-tool/)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
-

## PR 체크리스트 
> 모두 했는지 확인 후 PR
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [x] API 문서 반영 완료