### PR TITLE
[#65] refactor: API 문서 및 응답 DTO 리팩토링

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
     runtimeOnly 'org.postgresql:postgresql'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/auth/controller/AuthController.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/auth/controller/AuthController.java
@@ -15,6 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.grm3355.zonie.apiserver.domain.auth.dto.AuthResponse;
 import com.grm3355.zonie.apiserver.domain.auth.dto.LocationDto;
 import com.grm3355.zonie.apiserver.domain.auth.service.AuthService;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError400;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError405;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError415;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError429;
 import com.grm3355.zonie.commonlib.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,71 +36,26 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 	private final AuthService authService;
 
-	@Operation(summary = "사용자 토큰 발급", description = "위도, 경도 입력받아, Access 토큰을 발급합니다.")
-	// @checkstyle:off
+	@Operation(summary = "사용자 토큰 발급", description = "위경도 정보를 입력받아 사용자 Access 토큰을 발급합니다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "토큰 발급성공",
+			responseCode = "201",
+			description = "토큰 발급 성공 (신규 생성)",
 			content = @Content(
 				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
+				schema = @Schema(implementation = AuthResponse.class),
 				examples = @ExampleObject(
-					name = "OK",
+					name = "CREATED",
 					value = "{\"success\":true,\"data\":{\"accessToken\":\"...\"},\"timestamp\":\"2025-09-02T10:30:00.123456Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "400",
-			description = "입력값 유효성 검증 실패",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "BAD_REQUEST",
-					value = "{\"success\":false,\"status\":400,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "405",
-			description = "허용되지 않은 메소드",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "METHOD_NOT_ALLOWED",
-					value = "{\"success\":false,\"status\":405,\"error\":{\"code\":\"METHOD_NOT_ALLOWED\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "415",
-			description = "UNSUPPORTED_MEDIA_TYPE",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "UNSUPPORTED_MEDIA_TYPE",
-					value = "{\"success\":false,\"status\":415,\"error\":{\"code\":\"UNSUPPORTED_MEDIA_TYPE\",\"message\":\"잘못된 콘텐츠 타입입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "429",
-			description = "요청 횟수 초과",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "TOO_MANY_REQUESTS",
-					value = "{\"success\":false,\"status\":429,\"error\":{\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:45:00.123456Z\"}"
 				)
 			)
 		)
 	})
-	@PostMapping("/token-register")
+	@ApiError400
+	@ApiError405
+	@ApiError415
+	@ApiError429
+	@PostMapping("/tokens")
 	public ResponseEntity<?> register(@Valid @RequestBody LocationDto locationDto, HttpServletRequest request) {
 		String path = request != null ? request.getRequestURI() : null;
 		URI location = URI.create(Objects.requireNonNull(path));

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/chatroom/dto/MyChatRoomPageResponse.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/chatroom/dto/MyChatRoomPageResponse.java
@@ -1,0 +1,15 @@
+package com.grm3355.zonie.apiserver.domain.chatroom.dto;
+
+import org.springframework.data.domain.Page;
+
+import com.grm3355.zonie.apiserver.global.dto.PageResponse;
+
+/**
+ * Swagger가 제네릭 PageResponse<MyChatRoomResponse>를 (올바른 제네릭 DTO 추론을 통해)
+ * 문서화할 수 있도록 생성한 구체적인 DTO 클래스입니다.
+ */
+public class MyChatRoomPageResponse extends PageResponse<MyChatRoomResponse> {
+	public MyChatRoomPageResponse(Page<MyChatRoomResponse> page, int size) {
+		super(page, size);
+	}
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/controller/FestivalController.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/controller/FestivalController.java
@@ -1,10 +1,13 @@
 package com.grm3355.zonie.apiserver.domain.festival.controller;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -12,14 +15,23 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.grm3355.zonie.apiserver.domain.chatroom.dto.ChatRoomSearchRequest;
+import com.grm3355.zonie.apiserver.domain.festival.dto.FestivalCountResponse;
 import com.grm3355.zonie.apiserver.domain.festival.dto.FestivalCreateRequest;
+import com.grm3355.zonie.apiserver.domain.festival.dto.FestivalPageResponse;
 import com.grm3355.zonie.apiserver.domain.festival.dto.FestivalResponse;
 import com.grm3355.zonie.apiserver.domain.festival.dto.FestivalSearchRequest;
+import com.grm3355.zonie.apiserver.domain.festival.dto.RegionResponse;
 import com.grm3355.zonie.apiserver.domain.festival.service.FestivalService;
 import com.grm3355.zonie.apiserver.global.dto.PageResponse;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError400;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError405;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError415;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError429;
+import com.grm3355.zonie.commonlib.global.enums.Region;
 import com.grm3355.zonie.commonlib.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,145 +40,54 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 
 @RestController
-@Tag(name = "축제 목록 및 내용", description = "축제목록, 내용을 표시합니다.")
+@RequiredArgsConstructor
+@Tag(name = "Festivals", description = "축제 목록, 상세 정보 및 지역 목록을 조회합니다.")
 @RequestMapping("/api/v1")
 public class FestivalController {
 
 	private final FestivalService festivalService;
 
-	public FestivalController(FestivalService festivalService) {
-		this.festivalService = festivalService;
-	}
-
-	@Operation(summary = "축제 목록", description = "해당 축제의 목록을 볼 수 있다.")
+	@Operation(summary = "축제 목록 조회", description = "조건에 맞는 축제 목록을 페이지네이션하여 조회합니다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 			responseCode = "200",
-			description = "목록표시",
+			description = "목록 조회 성공",
 			content = @Content(
 				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "400",
-			description = "입력값 유효성 검증 실패",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "BAD_REQUEST",
-					value = "{\"success\":false,\"status\":400,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "405",
-			description = "허용되지 않은 메소드",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "METHOD_NOT_ALLOWED",
-					value = "{\"success\":false,\"status\":405,\"error\":{\"code\":\"METHOD_NOT_ALLOWED\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "415",
-			description = "UNSUPPORTED_MEDIA_TYPE",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "UNSUPPORTED_MEDIA_TYPE",
-					value = "{\"success\":false,\"status\":415,\"error\":{\"code\":\"UNSUPPORTED_MEDIA_TYPE\",\"message\":\"잘못된 콘텐츠 타입입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "429",
-			description = "요청 횟수 초과",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "TOO_MANY_REQUESTS",
-					value = "{\"success\":false,\"status\":429,\"error\":{\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:45:00.123456Z\"}"
-				)
+				schema = @Schema(implementation = FestivalPageResponse.class)
 			)
 		)
 	})
+	@ApiError400
+	@ApiError405
+	@ApiError415
+	@ApiError429
 	@GetMapping("/festivals")
 	public ResponseEntity<?> getFestivalList(@Valid @ModelAttribute FestivalSearchRequest request
 	) {
 		Page<FestivalResponse> pageList = festivalService.getFestivalList(request);
-		PageResponse<FestivalResponse> response = new PageResponse<>(pageList, request.getPageSize());
+		FestivalPageResponse response = new FestivalPageResponse(pageList, request.getPageSize());
 		return ResponseEntity.ok().body(ApiResponse.success(response));
 	}
 
-	@Operation(summary = "축제 내용", description = "해당 축제의 내용을 볼 수 있다.")
-	// @checkstyle:off
+	@Operation(summary = "축제 상세 조회", description = "특정 축제의 상세 정보를 조회합니다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 			responseCode = "200",
-			description = "내용표시",
+			description = "상세 조회 성공",
 			content = @Content(
 				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "400",
-			description = "입력값 유효성 검증 실패",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "BAD_REQUEST",
-					value = "{\"success\":false,\"status\":400,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "405",
-			description = "허용되지 않은 메소드",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "METHOD_NOT_ALLOWED",
-					value = "{\"success\":false,\"status\":405,\"error\":{\"code\":\"METHOD_NOT_ALLOWED\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "415",
-			description = "UNSUPPORTED_MEDIA_TYPE",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "UNSUPPORTED_MEDIA_TYPE",
-					value = "{\"success\":false,\"status\":415,\"error\":{\"code\":\"UNSUPPORTED_MEDIA_TYPE\",\"message\":\"잘못된 콘텐츠 타입입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "429",
-			description = "요청 횟수 초과",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "TOO_MANY_REQUESTS",
-					value = "{\"success\":false,\"status\":429,\"error\":{\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:45:00.123456Z\"}"
-				)
+				schema = @Schema(implementation = FestivalResponse.class)
 			)
 		)
 	})
+	@ApiError400
+	@ApiError405
+	@ApiError415
+	@ApiError429
 	@GetMapping("/festivals/{festivalId}")
 	public ResponseEntity<?> gefFestivalContent(@PathVariable long festivalId,
 		@ModelAttribute ChatRoomSearchRequest request
@@ -175,85 +96,71 @@ public class FestivalController {
 		return ResponseEntity.ok().body(ApiResponse.success(response));
 	}
 
-	@Operation(summary = "지역목록", description = "해당 축제의 내용을 볼 수 있다.")
-	// @checkstyle:off
+	@Operation(summary = "축제 지역 목록 조회", description = "축제가 열리는 지역(시/도) 목록을 조회합니다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 			responseCode = "200",
-			description = "내용표시",
+			description = "지역 목록 조회 성공",
 			content = @Content(
 				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "400",
-			description = "입력값 유효성 검증 실패",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "BAD_REQUEST",
-					value = "{\"success\":false,\"status\":400,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "405",
-			description = "허용되지 않은 메소드",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "METHOD_NOT_ALLOWED",
-					value = "{\"success\":false,\"status\":405,\"error\":{\"code\":\"METHOD_NOT_ALLOWED\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "415",
-			description = "UNSUPPORTED_MEDIA_TYPE",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "UNSUPPORTED_MEDIA_TYPE",
-					value = "{\"success\":false,\"status\":415,\"error\":{\"code\":\"UNSUPPORTED_MEDIA_TYPE\",\"message\":\"잘못된 콘텐츠 타입입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "429",
-			description = "요청 횟수 초과",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "TOO_MANY_REQUESTS",
-					value = "{\"success\":false,\"status\":429,\"error\":{\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:45:00.123456Z\"}"
-				)
+				schema = @Schema(type = "array", implementation = RegionResponse.class)
 			)
 		)
 	})
-	@GetMapping("/festivals/region")
+	@ApiError400
+	@ApiError405
+	@ApiError415
+	@ApiError429
+	@GetMapping("/festivals/regions")
 	public ResponseEntity<?> getFestivalRegion() {
-		List<?> response = festivalService.getRegionList();
+		List<?> rawList = festivalService.getRegionList();
+		List<RegionResponse> response = ((List<Map<String, String>>) rawList).stream()
+			.map(map -> new RegionResponse(map.get("region"), map.get("code")))
+			.toList();
 		return ResponseEntity.ok().body(ApiResponse.success(response));
 	}
 
-
 	@Operation(summary = "축제 생성 (테스트용)", description = "개발 테스트를 위해 새로운 축제 레코드를 생성합니다.")
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(
-		responseCode = "200",
-		description = "축제 생성 성공",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = ApiResponse.class)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+			responseCode = "200",	// 테스트용이라서 201로 굳이 설정하지 않음
+			description = "축제 생성 성공",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(implementation = FestivalResponse.class)
+			)
 		)
-	)
+	})
+	@ApiError400
+	@ApiError405
+	@ApiError415
+	@ApiError429
 	@PostMapping("/festivals")
 	public ResponseEntity<?> createFestival(@RequestBody FestivalCreateRequest request) {
 		FestivalResponse response = festivalService.createFestival(request);
 		return ResponseEntity.ok().body(ApiResponse.success(response));
+	}
+
+	@Operation(summary = "지역별 축제 개수 조회", description = "특정 지역(region)의 축제 개수를 조회합니다.")
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+			responseCode = "200",
+			description = "축제 개수 조회 성공",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(implementation = FestivalCountResponse.class)
+			)
+		)
+	})
+	@ApiError400 // (e.g., 유효하지 않은 region 파라미터)
+	@ApiError405
+	@ApiError415
+	@ApiError429
+	@GetMapping("/festivals/count")
+	public ResponseEntity<?> getFestivalCount(
+		@RequestParam("region") Region region // Enum으로 받음
+	) {
+		long count = festivalService.getFestivalCountByRegion(region);
+		return ResponseEntity.ok().body(ApiResponse.success(new FestivalCountResponse(count)));
 	}
 }

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/dto/FestivalCountResponse.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/dto/FestivalCountResponse.java
@@ -1,0 +1,13 @@
+package com.grm3355.zonie.apiserver.domain.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 특정 지역의 축제 개수를 반환하기 위한 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class FestivalCountResponse {
+	private long count;
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/dto/FestivalPageResponse.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/dto/FestivalPageResponse.java
@@ -1,0 +1,15 @@
+package com.grm3355.zonie.apiserver.domain.festival.dto;
+
+import org.springframework.data.domain.Page;
+
+import com.grm3355.zonie.apiserver.global.dto.PageResponse;
+
+/**
+ * Swagger가 제네릭 PageResponse<FestivalPageResponse>를 (올바른 제네릭 DTO 추론을 통해)
+ * 문서화할 수 있도록 생성한 구체적인 DTO 클래스입니다.
+ */
+public class FestivalPageResponse extends PageResponse<FestivalResponse> {
+	public FestivalPageResponse(Page<FestivalResponse> page, int size) {
+		super(page, size);
+	}
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/dto/RegionResponse.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/dto/RegionResponse.java
@@ -1,0 +1,17 @@
+package com.grm3355.zonie.apiserver.domain.festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Swagger가 제네릭 List<?>를 (올바른 제네릭 DTO 추론을 통해)
+ * 문서화할 수 있도록 생성한 ('region'과 'code'를 담는) 구체적인 DTO 클래스입니다.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegionResponse {
+	private String region;
+	private String code;
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/service/FestivalService.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/festival/service/FestivalService.java
@@ -124,11 +124,38 @@ public class FestivalService {
 	 * 지역분류 가져오기
 	 * @return list
 	 */
-	public List<?> getRegionList() {
+	public List<Map<String, String>> getRegionList() {
 		return Arrays.stream(Region.values()).map(region -> Map.of(
 			"region", region.getName(),
 			"code", region.name()
 		)).toList();
+	}
+
+	/**
+	 * 지역별 축제 개수 조회
+	 * (getFestivalListType의 필터 조건 중 'preview_days'를 동일하게 적용)
+	 *
+	 * @param region Region Enum
+	 * @return 해당 지역의 축제 개수
+	 */
+	@Transactional(readOnly = true)
+	public long getFestivalCountByRegion(Region region) {
+		if (region == null) {
+			throw new BusinessException(ErrorCode.BAD_REQUEST, "지역 코드를 정확하게 입력하세요. 지역코드 정보는 다음과 같습니다.\n SEOUL(\"서울\"),\n"
+				+ "\tGYEONGGI(\"경기/인천\"),\n"
+				+ "\tCHUNGCHEONG(\"충청/대전/세종\"),\n"
+				+ "\tGANGWON(\"강원\"),\n"
+				+ "\tGYEONGBUK(\"경북/대구/울산\"),\n"
+				+ "\tGYEONGNAM(\"경남/부산\"),\n"
+				+ "\tJEOLLA(\"전라/광주\"),\n"
+				+ "\tJEJU(\"제주\")}");
+		}
+
+		// 3. Repository에 count용 메서드 호출: getFestivalList와 동일하게 preview_days를 적용하여 노출될 축제만 카운트
+		return festivalRepository.countFestivalsByRegion(
+			region.toString(),
+			preview_days
+		);
 	}
 
 	/**

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/location/dto/ChatRoomZoneVerifyResponse.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/location/dto/ChatRoomZoneVerifyResponse.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ChatRoomZoneVarifyResponse(
+public record ChatRoomZoneVerifyResponse(
 	@Schema(description = "접근여부", example = "true")
 	boolean accessValue,
 

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/location/dto/FestivalZoneVerifyResponse.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/location/dto/FestivalZoneVerifyResponse.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record FestivalZoneVarifyResponse(
+public record FestivalZoneVerifyResponse(
 	@Schema(description = "접근여부", example = "true")
 	boolean accessValue,
 

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/message/controller/MessageController.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/message/controller/MessageController.java
@@ -13,10 +13,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.grm3355.zonie.apiserver.domain.message.dto.MessageLikeResponse;
 import com.grm3355.zonie.apiserver.domain.message.dto.MessageResponse;
+import com.grm3355.zonie.apiserver.domain.message.dto.MessageSliceResponse;
 import com.grm3355.zonie.apiserver.domain.message.service.MessageLikeService;
 import com.grm3355.zonie.apiserver.domain.message.service.MessageQueryService;
 import com.grm3355.zonie.apiserver.global.jwt.UserDetailsImpl;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError400;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError404;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError405;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError415;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError429;
 import com.grm3355.zonie.commonlib.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +35,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@Tag(name = "메시지 기능", description = "메시지 좋아요, 과거 내역 조회 등")
+@Tag(name = "Messages", description = "메시지 좋아요, 과거 내역 조회 등")
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class MessageController {
@@ -38,7 +45,10 @@ public class MessageController {
 
 	@Operation(summary = "메시지 '좋아요' 토글", description = "메시지 '좋아요'를 누르거나 취소합니다. (위치 인증 필요)")
 	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+			responseCode = "200", description = "좋아요 토글 성공",
+			content = @Content(mediaType = "application/json",
+				schema = @Schema(implementation = MessageLikeResponse.class),
 			examples = {
 				@ExampleObject(name = "좋아요 누르기 성공",
 					value = "{\"success\":true,\"data\":{\"liked\":true,\"likeCount\":6},\"error\":null,\"timestamp\":\"2025-09-02T10:30:00.123456Z\"}"),
@@ -46,6 +56,7 @@ public class MessageController {
 					value = "{\"success\":true,\"data\":{\"liked\":false,\"likeCount\":5},\"error\":null,\"timestamp\":\"2025-09-02T10:30:00.123456Z\"}")
 			}
 		)),
+		// 400, 401, 403, 404 ( -> 고유한 설명 사용)
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력값 유효성 검증 실패 (e.g., messageId 형식 오류)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class),
 			examples = @ExampleObject(name = "BAD_REQUEST",
 				value = "{\"success\":false,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}")
@@ -61,37 +72,52 @@ public class MessageController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "메시지 또는 채팅방을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class),
 			examples = @ExampleObject(name = "NOT_FOUND",
 				value = "{\"success\":false,\"error\":{\"code\":\"NOT_FOUND\",\"message\":\"메시지를 찾을 수 없습니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}")
-		)),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "요청 횟수 초과", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class),
-			examples = @ExampleObject(name = "TOO_MANY_REQUESTS",
-				value = "{\"success\":false,\"error\":{\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"요청 횟수를 초과했습니다.\"},\"timestamp\":\"2025-09-02T10:45:00.123456Z\"}")
 		))
 	})
+	@ApiError405
+	@ApiError415
+	@ApiError429
 	@PostMapping("/messages/{messageId}/like")
 	@PreAuthorize("hasAnyRole('GUEST', 'USER')")
-	public ResponseEntity<ApiResponse<Map<String, Object>>> toggleLike(
+	public ResponseEntity<ApiResponse<MessageLikeResponse>> toggleLike(
 		@PathVariable String messageId,
 		@AuthenticationPrincipal UserDetailsImpl userDetails
 	) {
 		String userId = userDetails.getUsername();
 		Map<String, Object> result = messageLikeService.toggleLike(userId, messageId);
-		return ResponseEntity.ok(ApiResponse.success(result));
+		MessageLikeResponse response = new MessageLikeResponse(
+			(Boolean) result.get("liked"),
+			((Number) result.get("likeCount")).longValue() // Integer든 Long이든 long으로 변환
+		);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
 	@Operation(summary = "채팅방 과거 메시지 조회", description = "채팅방의 과거 메시지 목록을 커서 기반 페이지네이션으로 조회합니다.")
 	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+			responseCode = "200",
+			description = "조회 성공",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(implementation = MessageSliceResponse.class)
+			)
+		),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
 	})
+	@ApiError400
+	@ApiError404
+	@ApiError405
+	@ApiError429
 	@GetMapping("/chat-rooms/{roomId}/messages")
 	@PreAuthorize("hasAnyRole('GUEST', 'USER')")
-	public ResponseEntity<ApiResponse<Slice<MessageResponse>>> getMessages(
+	public ResponseEntity<ApiResponse<MessageSliceResponse>> getMessages(
 		@PathVariable String roomId,
 		@RequestParam(required = false) String before, // (커서 ID)
 		@AuthenticationPrincipal UserDetailsImpl userDetails
 	) {
 		String userId = userDetails.getUsername();
 		Slice<MessageResponse> messages = messageQueryService.getMessages(roomId, userId, before);
-		return ResponseEntity.ok(ApiResponse.success(messages));
+		MessageSliceResponse response = new MessageSliceResponse(messages);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/message/dto/MessageLikeResponse.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/message/dto/MessageLikeResponse.java
@@ -1,0 +1,15 @@
+package com.grm3355.zonie.apiserver.domain.message.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Swagger가 제네릭 Map<String, Object>를 (올바른 제네릭 DTO 추론을 통해)
+ * 문서화할 수 있도록 생성한 구체적인 DTO 클래스입니다.
+ */
+@Getter
+@AllArgsConstructor
+public class MessageLikeResponse {
+	private boolean liked;
+	private long likeCount;
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/message/dto/MessageSliceResponse.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/message/dto/MessageSliceResponse.java
@@ -1,0 +1,22 @@
+package com.grm3355.zonie.apiserver.domain.message.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+
+import lombok.Getter;
+
+/**
+ * Swagger가 제네릭 Slice<MessageResponse>를 (올바른 제네릭 DTO 추론을 통해)
+ * 문서화할 수 있도록 생성한 구체적인 DTO 클래스입니다.
+ */
+@Getter
+public class MessageSliceResponse {
+	private final List<MessageResponse> content;
+	private final boolean hasNext;
+
+	public MessageSliceResponse(Slice<MessageResponse> slice) {
+		this.content = slice.getContent();
+		this.hasNext = slice.hasNext();
+	}
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/search/controller/TotalSearchController.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/search/controller/TotalSearchController.java
@@ -10,92 +10,48 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.grm3355.zonie.apiserver.domain.chatroom.dto.ChatRoomSearchRequest;
+import com.grm3355.zonie.apiserver.domain.chatroom.dto.MyChatRoomPageResponse;
 import com.grm3355.zonie.apiserver.domain.chatroom.dto.MyChatRoomResponse;
-import com.grm3355.zonie.apiserver.domain.festival.dto.FestivalResponse;
-import com.grm3355.zonie.apiserver.domain.festival.dto.FestivalSearchRequest;
 import com.grm3355.zonie.apiserver.domain.search.dto.TotalSearchDto;
 import com.grm3355.zonie.apiserver.domain.search.dto.TotalSearchResponse;
 import com.grm3355.zonie.apiserver.domain.search.service.TotalSearchService;
 import com.grm3355.zonie.apiserver.global.dto.PageResponse;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError400;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError405;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError415;
+import com.grm3355.zonie.apiserver.global.swagger.ApiError429;
 import com.grm3355.zonie.commonlib.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 
 @RestController
-@Tag(name = "통합검색", description = "축제, 채팅방 목록을 표시합니다.")
+@Tag(name = "Search (통합 검색)", description = "축제 및 채팅방 통합 검색")
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class TotalSearchController {
 
 	private final TotalSearchService totalSearchService;
 
-	public TotalSearchController(TotalSearchService totalSearchService) {
-		this.totalSearchService = totalSearchService;
-	}
-
-	@Operation(summary = "축제목록 + 채팅방목록", description = "해당 축제의 내용을 볼 수 있다.")
+	@Operation(summary = "통합 검색 (축제 + 채팅방)", description = "키워드로 축제 목록과 채팅방 목록을 함께 검색합니다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 			responseCode = "200",
-			description = "목록표시",
+			description = "목록 검색 성공",
 			content = @Content(
 				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "400",
-			description = "입력값 유효성 검증 실패",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "BAD_REQUEST",
-					value = "{\"success\":false,\"status\":400,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "405",
-			description = "허용되지 않은 메소드",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "METHOD_NOT_ALLOWED",
-					value = "{\"success\":false,\"status\":405,\"error\":{\"code\":\"METHOD_NOT_ALLOWED\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "415",
-			description = "UNSUPPORTED_MEDIA_TYPE",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "UNSUPPORTED_MEDIA_TYPE",
-					value = "{\"success\":false,\"status\":415,\"error\":{\"code\":\"UNSUPPORTED_MEDIA_TYPE\",\"message\":\"잘못된 콘텐츠 타입입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "429",
-			description = "요청 횟수 초과",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "TOO_MANY_REQUESTS",
-					value = "{\"success\":false,\"status\":429,\"error\":{\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:45:00.123456Z\"}"
-				)
+				schema = @Schema(implementation = TotalSearchResponse.class)
 			)
 		)
 	})
+	@ApiError400
+	@ApiError405
+	@ApiError415
+	@ApiError429
 	@GetMapping("/search")
 	public ResponseEntity<?> getTotalSearch(@Valid @ModelAttribute TotalSearchDto request
 	) {
@@ -103,141 +59,26 @@ public class TotalSearchController {
 		return ResponseEntity.ok().body(ApiResponse.success(response));
 	}
 
-	@Operation(summary = "통합검색 - 축제 목록", description = "통합검색에서 축제목록을 볼 수 있다.")
-	// @checkstyle:off
+	@Operation(summary = "검색 - 채팅방 목록", description = "검색 결과 중 내 채팅방 목록만 상세 조회합니다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 			responseCode = "200",
-			description = "내용표시",
+			description = "채팅방 목록 조회 성공",
 			content = @Content(
 				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "400",
-			description = "입력값 유효성 검증 실패",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "BAD_REQUEST",
-					value = "{\"success\":false,\"status\":400,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "405",
-			description = "허용되지 않은 메소드",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "METHOD_NOT_ALLOWED",
-					value = "{\"success\":false,\"status\":405,\"error\":{\"code\":\"METHOD_NOT_ALLOWED\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "415",
-			description = "UNSUPPORTED_MEDIA_TYPE",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "UNSUPPORTED_MEDIA_TYPE",
-					value = "{\"success\":false,\"status\":415,\"error\":{\"code\":\"UNSUPPORTED_MEDIA_TYPE\",\"message\":\"잘못된 콘텐츠 타입입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "429",
-			description = "요청 횟수 초과",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "TOO_MANY_REQUESTS",
-					value = "{\"success\":false,\"status\":429,\"error\":{\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:45:00.123456Z\"}"
-				)
+				schema = @Schema(implementation = MyChatRoomPageResponse.class)
 			)
 		)
 	})
-	@GetMapping("/search/festivals")
-	public ResponseEntity<?> getFestivalTotalSearch(@Valid @ModelAttribute FestivalSearchRequest request
-	) {
-		//FestivalSearchRequest
-		Page<FestivalResponse> pageList = totalSearchService.getFestivalTotalSearch(request);
-		PageResponse<FestivalResponse> response = new PageResponse<>(pageList, request.getPageSize());
-		return ResponseEntity.ok().body(ApiResponse.success(response));
-	}
-
-	@Operation(summary = "통합검색 - 채팅방 목록", description = "통합검색에서 채팅방 목록을 볼 수 있다.")
-	// @checkstyle:off
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "내용표시",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "400",
-			description = "입력값 유효성 검증 실패",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "BAD_REQUEST",
-					value = "{\"success\":false,\"status\":400,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "405",
-			description = "허용되지 않은 메소드",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "METHOD_NOT_ALLOWED",
-					value = "{\"success\":false,\"status\":405,\"error\":{\"code\":\"METHOD_NOT_ALLOWED\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "415",
-			description = "UNSUPPORTED_MEDIA_TYPE",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "UNSUPPORTED_MEDIA_TYPE",
-					value = "{\"success\":false,\"status\":415,\"error\":{\"code\":\"UNSUPPORTED_MEDIA_TYPE\",\"message\":\"잘못된 콘텐츠 타입입니다.\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}"
-				)
-			)
-		),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "429",
-			description = "요청 횟수 초과",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = ApiResponse.class),
-				examples = @ExampleObject(
-					name = "TOO_MANY_REQUESTS",
-					value = "{\"success\":false,\"status\":429,\"error\":{\"code\":\"TOO_MANY_REQUESTS\",\"message\":\"잘못된 요청입니다.\"},\"timestamp\":\"2025-09-02T10:45:00.123456Z\"}"
-				)
-			)
-		)
-	})
-	@GetMapping("/search/chatrooms")
+	@ApiError400
+	@ApiError405
+	@ApiError415
+	@ApiError429
+	@GetMapping("/search/chat-rooms")
 	public ResponseEntity<?> getChatroomTotalSearch(@Valid @ModelAttribute ChatRoomSearchRequest request
 	) {
 		Page<MyChatRoomResponse> pageList = totalSearchService.getChatroomTotalSearch(request);
-		PageResponse<MyChatRoomResponse> response = new PageResponse<>(pageList, request.getPageSize());
+		MyChatRoomPageResponse response = new MyChatRoomPageResponse(pageList, request.getPageSize());
 		return ResponseEntity.ok().body(ApiResponse.success(response));
-
 	}
 }

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/config/SwaggerConfig.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/config/SwaggerConfig.java
@@ -11,6 +11,9 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
 
 /**
  * OpenAPI 3.0 (Swagger) 문서 생성을 위한 설정 클래스.
@@ -19,13 +22,14 @@ import io.swagger.v3.oas.models.info.Info;
  */
 @OpenAPIDefinition(
 	servers = {
+		@Server(url = "https://www.zony.kro.kr", description = "운영 서버"),
 		@Server(url = "http://localhost:8080", description = "로컬 서버")
 	})
 @Configuration
 @SecurityScheme(
 	name = "Authorization",
 	type = SecuritySchemeType.HTTP,
-	scheme = "bearer",
+	scheme = "Bearer",
 	bearerFormat = "JWT",
 	description = "JWT Access Token"
 )
@@ -39,15 +43,84 @@ import io.swagger.v3.oas.models.info.Info;
 public class SwaggerConfig {
 	@Bean
 	public OpenAPI openApi() {
+		// 1. 공통 응답(ApiResponse) 스키마 정의
+		Schema<?> apiResponseSchema = new Schema<>()
+			.name("ApiResponse")
+			.type("object")
+			.addProperty("success", new Schema<>().type("boolean"))
+			.addProperty("data", new Schema<>().type("object").nullable(true))
+			.addProperty("error", new Schema<>()
+				.$ref("#/components/schemas/ErrorResponse")
+				.nullable(true))
+			.addProperty("timestamp", new Schema<>().type("string").format("date-time"));
+
+		// 2. 공통 에러(ErrorResponse) 스키마 정의
+		Schema<?> errorResponseSchema = new Schema<>()
+			.name("ErrorResponse")
+			.type("object")
+			.addProperty("code", new Schema<>().type("string"))
+			.addProperty("message", new Schema<>().type("string"));
+
+		// 3. Components 객체 생성, 위에서 정의한 스키마들 추가
+		Components components = new Components()
+			.addSchemas("ApiResponse", apiResponseSchema)
+			.addSchemas("ErrorResponse", errorResponseSchema);
+
+		// 4. 공통 에러 응답들 Components에 추가
+		addErrorResponse(components, "400", "BadRequest", "입력값 유효성 검증 실패");
+		addErrorResponse(components, "401", "Unauthorized", "인증 실패 (토큰 누락 또는 만료)");
+		addErrorResponse(components, "403", "Forbidden", "권한 없음");
+		addErrorResponse(components, "404", "NotFound", "요청한 리소스 없음");
+		addErrorResponse(components, "405", "MethodNotAllowed", "허용되지 않은 메소드");
+		addErrorResponse(components, "415", "UnsupportedMediaType", "지원되지 않는 미디어 타입");
+		addErrorResponse(components, "429", "TooManyRequests", "요청 횟수 초과");
+		addErrorResponse(components, "500", "InternalServerError", "서버 내부 로직 오류");
+
+		// 5. 204 No Content 공통 응답 등록
+		components.addResponses("NoContent",
+			new io.swagger.v3.oas.models.responses.ApiResponse()
+				.description("정상 처리 (콘텐츠 없음)")
+				.content(null) // 바디가 없음을 명시
+		);
+
 		return new OpenAPI()
-			.components(new Components())
+			.components(components) // 수정된 components 주입
 			.info(apiInfo());
 	}
 
 	private Info apiInfo() {
 		return new Info()
 			.title("Swagger")
-			.description("모든 REST API")
-			.version("1.0.0");
+			.description("Zonie REST API")
+			.version("1.0.1");
+	}
+
+	/**
+	 * 공통 에러 응답을 Components에 추가하는 헬퍼 메서드
+	 *
+	 * @param components  수정할 Components 객체
+	 * @param httpCode    HTTP 상태 코드 (예: "400")
+	 * @param name        컴포넌트 참조 이름 (예: "BadRequest")
+	 * @param description 에러 설명
+	 */
+	private void addErrorResponse(Components components, String httpCode, String name, String description) {
+		// 공통 ApiResponse 스키마를 참조하도록 설정
+		Schema<?> schema = new Schema<>().$ref("#/components/schemas/ApiResponse");
+
+		// JSON 예시 생성
+		String exampleJson = String.format(
+			"{\"success\":false,\"data\":null,\"error\":{\"code\":\"%s\",\"message\":\"%s\"},\"timestamp\":\"2025-09-02T10:35:00.987654Z\"}",
+			name.toUpperCase(), // ex) BAD_REQUEST
+			description
+		);
+		Content content = new Content()
+			.addMediaType("application/json", new MediaType()
+				.schema(schema)
+				.example(exampleJson));
+
+		// Components에 Response 등록
+		components.addResponses(name, new io.swagger.v3.oas.models.responses.ApiResponse()
+			.description(description)
+			.content(content));
 	}
 }

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/controller/HealthCheckController.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/controller/HealthCheckController.java
@@ -4,6 +4,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Hidden;
+
+@Hidden
 @RestController
 public class HealthCheckController {
 

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiDefault.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiDefault.java
@@ -1,0 +1,22 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+/**
+ * 공통 Swagger Error Response (400, 405, 415, 429)를 묶어주는 커스텀 어노테이션 (+ 204까지)
+ * : SwaggerConfig에 등록한 Components를 $ref로 참조합니다.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "400", ref = "#/components/responses/BadRequest")
+@ApiResponse(responseCode = "405", ref = "#/components/responses/MethodNotAllowed")
+@ApiResponse(responseCode = "415", ref = "#/components/responses/UnsupportedMediaType")
+@ApiResponse(responseCode = "429", ref = "#/components/responses/TooManyRequests")
+@ApiResponse(responseCode = "204", ref = "#/components/responses/NoContent")
+public @interface ApiDefault {
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError400.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError400.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "400", ref = "#/components/responses/BadRequest")
+public @interface ApiError400 {
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError401.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError401.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "401", ref = "#/components/responses/Unauthorized")
+public @interface ApiError401 {
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError403.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError403.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "403", ref = "#/components/responses/Forbidden")
+public @interface ApiError403 {
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError404.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError404.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "404", ref = "#/components/responses/NotFound")
+public @interface ApiError404 {
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError405.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError405.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "405", ref = "#/components/responses/MethodNotAllowed")
+public @interface ApiError405 {
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError415.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError415.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "415", ref = "#/components/responses/UnsupportedMediaType")
+public @interface ApiError415 {
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError429.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiError429.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "429", ref = "#/components/responses/TooManyRequests")
+public @interface ApiError429 {
+}

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiSuccess204.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/global/swagger/ApiSuccess204.java
@@ -1,0 +1,14 @@
+package com.grm3355.zonie.apiserver.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(responseCode = "204", ref = "#/components/responses/NoContent")
+public @interface ApiSuccess204 {
+}

--- a/api-server/src/main/resources/application-prod.yml
+++ b/api-server/src/main/resources/application-prod.yml
@@ -60,3 +60,7 @@ location:
     ttl-minutes: 15
   radius:
     limit: 1.0
+
+springdoc:
+  swagger-ui:
+    enabled: true # 실제 운영 환경에서는 false로 변경하기

--- a/api-server/src/test/java/com/grm3355/zonie/apiserver/domain/auth/controller/AuthControllerTest.java
+++ b/api-server/src/test/java/com/grm3355/zonie/apiserver/domain/auth/controller/AuthControllerTest.java
@@ -73,7 +73,7 @@ class AuthControllerTest {
 			ArgumentMatchers.any(LocationDto.class))
 		).thenReturn(mockResponse);
 
-		mockMvc.perform(post("/api/v1/auth/token-register")
+		mockMvc.perform(post("/api/v1/auth/tokens")
 				.header("Authorization", "Bearer test")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(locationDto)))

--- a/api-server/src/test/java/com/grm3355/zonie/apiserver/domain/festival/controller/FestivalControllerTest.java
+++ b/api-server/src/test/java/com/grm3355/zonie/apiserver/domain/festival/controller/FestivalControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,14 +70,13 @@ class FestivalControllerTest {
 		// given
 		FestivalResponse festival = FestivalResponse.builder().build();
 		Page<FestivalResponse> pageList = new PageImpl<>(List.of(festival), PageRequest.of(0, 10), 1);
-		PageResponse<FestivalResponse> pageResponse = new PageResponse<>(pageList, 10);
 
-		Mockito.when(festivalService.getFestivalList(any(FestivalSearchRequest.class)))
+		Mockito.when(festivalService.getFestivalList(any(FestivalSearchRequest.class))) // 서비스에서 Page<T> 반환 (컨트롤러가 FestivalPageResponse로 변환)
 			.thenReturn(pageList);
 
 		// when & then
 		mockMvc.perform(get("/api/v1/festivals")
-				.param("page", "0")
+				.param("page", "1")
 				.param("pageSize", "10")
 				.param("region", "SEOUL")
 				.param("status", "ALL")
@@ -85,7 +85,8 @@ class FestivalControllerTest {
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data").exists());
+			.andExpect(jsonPath("$.data.content[0]").exists())
+			.andExpect(jsonPath("$.data.totalElements").value(1));
 	}
 
 	@Test
@@ -98,8 +99,6 @@ class FestivalControllerTest {
 
 		// when & then
 		mockMvc.perform(get("/api/v1/festivals/{festivalId}", 1)
-				.param("keyword", "테스트")
-				.param("order", "DATE_ASC")
 				.contentType(MediaType.APPLICATION_JSON)
 			)
 			.andExpect(status().isOk())
@@ -111,18 +110,42 @@ class FestivalControllerTest {
 	@DisplayName("지역 목록 조회 테스트")
 	void testGetFestivalRegion() throws Exception {
 		// given
-		List<Region> regions = List.of(Region.SEOUL, Region.JEOLLA);
+		List<Map<String, String>> serviceResponse = List.of(
+			Map.of("region", "서울", "code", "SEOUL"),
+			Map.of("region", "전라", "code", "JEOLLA")
+		);
+
 		Mockito.when(festivalService.getRegionList())
-			.thenReturn((List)regions);
+			.thenReturn(serviceResponse);
+
 		// when & then
-		mockMvc.perform(get("/api/v1/festivals/region")
+		mockMvc.perform(get("/api/v1/festivals/regions")
 				.contentType(MediaType.APPLICATION_JSON)
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data").isArray())
-			.andExpect(jsonPath("$.data[0]").value("SEOUL"))
-			.andExpect(jsonPath("$.data[1]").value("JEOLLA"));
+			.andExpect(jsonPath("$.data[0].region").value("서울"))
+			.andExpect(jsonPath("$.data[0].code").value("SEOUL"))
+			.andExpect(jsonPath("$.data[1].region").value("전라"))
+			.andExpect(jsonPath("$.data[1].code").value("JEOLLA"));
+	}
+
+	@Test
+	@DisplayName("지역별 축제 개수 조회 테스트")
+	void testGetFestivalCount() throws Exception {
+		// given
+		Mockito.when(festivalService.getFestivalCountByRegion(eq(Region.SEOUL)))
+			.thenReturn(15L); // "서울" 지역 축제 15개
+
+		// when & then
+		mockMvc.perform(get("/api/v1/festivals/count")
+				.param("region", "SEOUL") // Region Enum 이름과 일치
+				.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.count").value(15)); // FestivalCountResponse DTO 검증
 	}
 
 	@Test

--- a/chat-server/src/main/resources/application-prod.yml
+++ b/chat-server/src/main/resources/application-prod.yml
@@ -26,7 +26,7 @@ spring:
   # --- JPA (운영용) ---
   jpa:
     hibernate:
-      ddl-auto: none  # 운영 환경에서는 validate 또는 none 사용
+      ddl-auto: update  # 운영 환경에서는 validate 또는 none 사용
     show-sql: false     # 운영 환경에서는 SQL 로그를 꺼서 성능 확보
 
 logging:

--- a/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/chatroom/entity/ChatRoom.java
+++ b/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/chatroom/entity/ChatRoom.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;

--- a/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/festival/repository/FestivalRepository.java
+++ b/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/festival/repository/FestivalRepository.java
@@ -114,4 +114,19 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
 		nativeQuery = true)
 	Page<Festival> getFestivalLocationBased(double lat, double lon, double radius,
 		int dayNum, Pageable pageable);
+
+	/**
+	 * 특정 지역의 축제 개수 조회
+	 */
+	@Query(
+		value = """
+			SELECT COUNT(*)
+			FROM festivals f
+			WHERE f.region = :region
+			AND (CURRENT_TIMESTAMP >= (f.event_start_date - make_interval(days => :dayNum))
+			     AND CURRENT_TIMESTAMP <= f.event_end_date)
+			""",
+		nativeQuery = true
+	)
+	long countFestivalsByRegion(@Param("region") String region, @Param("dayNum") int dayNum);
 }


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: #57
- 서브 이슈: Resolved: closed: #65

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- SwaggerConfig에 공통 응답 등록
- API 추가: `GET /api/v1/festivals/count` (지역별 축제 개수): FestivalController, FestivalService, FestivalRepository
- API 네이밍 컨벤션에 맞게 수정
- `HealthCheckController`를 `@Hidden`으로 문서에서 숨김
- `Varify` -> `Verify` DTO 오타 수정
- 변경된 API 명세(URL, DTO, Service Mock)에 맞춰 모든 테스트 코드 수정

## 변경 이유
> 왜 이 변경이 필요한지 설명
- 코드 정리: 기존 컨트롤러 코드에 @ApiResponses 어노테이션이 반복적으로 중복됨
- API 문서 정확도 향상: 제네릭 DTO는 Swagger UI에서 data: {}로 표시되는 문제 해결

## 테스트
> 어떤 방법으로 검증했는지 작성
- Swagger UI

## 참고 자료 (선택)
- 

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
- 

## PR 체크리스트 
> 모두 했는지 확인 후 PR
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [x] API 문서 반영 완료