### PR TITLE
[#46] refactor: 위치 검증 로직 개선 적용

### DIFF
--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/chatroom/dto/ChatRoomRequest.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/chatroom/dto/ChatRoomRequest.java
@@ -15,4 +15,12 @@ public class ChatRoomRequest {
 	@NotBlank(message = "채팅방 제목은 필수입니다.")
 	private String title;
 
+	@Schema(description = "위도", example = "37.5894939323")
+	@NotNull(message = "위도 값은 필수입니다.")
+	private double lat;
+
+	@Schema(description = "경도", example = "127.0167863252")
+	@NotNull(message = "경도 값은 필수입니다.")
+	private double lon;
+
 }

--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/chatroom/service/FestivalInfoService.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/chatroom/service/FestivalInfoService.java
@@ -29,4 +29,19 @@ public class FestivalInfoService {
 	public void increaseChatRoomCount(Long festivalId) {
 		festivalRepository.updateFestivalChatRoomCount(festivalId);
 	}
+
+	/**
+	 * 사용자가 축제 반경 내에 있는지 PostGIS를 이용해 검증합니다.
+	 * @param festivalId 축제 ID
+	 * @param lat 사용자 위도
+	 * @param lon 사용자 경도
+	 * @param maxRadius 최대 허용 반경 (km)
+	 * @return 반경 내에 있으면 true
+	 */
+	public boolean isUserWithinFestivalRadius(long festivalId, double lat, double lon, double maxRadius) {
+		// PostGIS 쿼리(findDistanceToFestival)를 호출하여 거리를 km 단위로 가져옵니다.
+		double distanceKm = festivalRepository.findDistanceToFestival(festivalId, lon, lat)
+			.orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "축제 위치 정보를 찾을 수 없습니다."));
+		return distanceKm <= maxRadius;
+	}
 }

--- a/api-server/src/main/resources/application-dev.yml
+++ b/api-server/src/main/resources/application-dev.yml
@@ -28,11 +28,15 @@ spring:
     redis:
       time-to-live: 600000 # 10분 (밀리초)
 
-#logging:
-#  level:
-#    root: TRACE
-#    org.springframework: TRACE
-#    org.hibernate.SQL: TRACE
-#    org.springframework.orm.jpa: TRACE
-#    org.springframework.beans.factory: TRACE
-#    org.hibernate.type.descriptor.sql.BasicBinder: TRACE  # 바인딩 값 출력
+chat:
+  max-chat-person: 300
+  max-chat-room: 30
+  radius: 1.0 #km
+  pre-create-day: 7 #7일전부터 생성 가능
+  pre-view-day: 7 #7일전부터 축제보기 가능
+
+location:
+  token:
+    ttl-minutes: 15
+  radius:
+    limit: 1.0

--- a/api-server/src/main/resources/application-prod.yml
+++ b/api-server/src/main/resources/application-prod.yml
@@ -49,7 +49,7 @@ openapi:
 
 #채팅 기본정보
 chat:
-  max-chat-person: 500
+  max-chat-person: 300
   max-chat-room: 30
   radius: 1.0 #km
   pre-create-day: 7 #7일전부터 생성 가능

--- a/api-server/src/test/java/com/grm3355/zonie/apiserver/domain/chatroom/ChatRoomControllerTest.java
+++ b/api-server/src/test/java/com/grm3355/zonie/apiserver/domain/chatroom/ChatRoomControllerTest.java
@@ -28,7 +28,6 @@ import com.grm3355.zonie.apiserver.domain.chatroom.service.ChatRoomService;
 
 @DisplayName("채팅방 생성 통합테스트")
 @SpringBootTest
-	// @AutoConfigureMockMvc
 class ChatRoomControllerTest extends BaseIntegrationTest {
 
 	@Autowired
@@ -44,11 +43,17 @@ class ChatRoomControllerTest extends BaseIntegrationTest {
 	@DisplayName("채팅방 생성 성공")
 	@WithMockUser(roles = "GUEST")
 	void createChatRoomTest() throws Exception {
-		ChatRoomRequest request = ChatRoomRequest.builder().title("테스트 채팅방").build();
+		ChatRoomRequest request = ChatRoomRequest.builder()
+			.title("테스트 채팅방")
+			.lat(37.5665)
+			.lon(126.9780)
+			.build();
 
 		ChatRoomResponse response = ChatRoomResponse.builder()
 			.chatRoomId(String.valueOf(1L))
 			.title(request.getTitle())
+			.lat(request.getLat())
+			.lon(request.getLon())
 			.build();
 
 		when(chatRoomService.setCreateChatRoom(anyLong(), any(ChatRoomRequest.class), any()))
@@ -59,6 +64,8 @@ class ChatRoomControllerTest extends BaseIntegrationTest {
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.data.chatRoomId").value(1L))
+			.andExpect(jsonPath("$.data.lat").value(request.getLat()))
+			.andExpect(jsonPath("$.data.lon").value(request.getLon()))
 			.andExpect(jsonPath("$.data.title").value("테스트 채팅방"));
 	}
 

--- a/chat-server/src/main/java/com/grm3355/zonie/chatserver/service/ChatLocationService.java
+++ b/chat-server/src/main/java/com/grm3355/zonie/chatserver/service/ChatLocationService.java
@@ -1,5 +1,8 @@
 package com.grm3355.zonie.chatserver.service;
 
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -8,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.grm3355.zonie.chatserver.dto.ChatUserLocationDto;
 import com.grm3355.zonie.commonlib.domain.chatroom.entity.ChatRoom;
 import com.grm3355.zonie.commonlib.domain.chatroom.repository.ChatRoomRepository;
+import com.grm3355.zonie.commonlib.domain.festival.repository.FestivalRepository;
 import com.grm3355.zonie.commonlib.global.exception.BusinessException;
 import com.grm3355.zonie.commonlib.global.exception.ErrorCode;
 
@@ -16,16 +20,29 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class ChatLocationService {
 
 	private final StringRedisTemplate redisTemplate;
+	private final FestivalRepository festivalRepository;
 	private final ChatRoomRepository chatRoomRepository;
+	private final ObjectMapper objectMapper; // DTO 역직렬화를 위해 추가
+	private final Duration tokenTtl;
+	@Value("${chat.radius}")
+	private double max_radius;
+
+	public ChatLocationService(StringRedisTemplate redisTemplate, ChatRoomRepository chatRoomRepository, ObjectMapper objectMapper, @Value("${location.token.ttl-minutes}") long ttlMinutes,
+		FestivalRepository festivalRepository) {
+		this.redisTemplate = redisTemplate;
+		this.chatRoomRepository = chatRoomRepository;
+		this.objectMapper = objectMapper;
+		this.tokenTtl = Duration.ofMinutes(ttlMinutes);
+		this.festivalRepository = festivalRepository;
+	}
 
 	// Redis에서 토큰의 존재 여부만 확인
 	private void validateLocationToken(String userId, Long festivalId) {
 		// api-server의 RedisTokenService.buildKey와 동일한 키 사용
-		String redisKey = "locationToken:" + userId + ":" + String.valueOf(festivalId);
+		String redisKey = buildKey(userId, String.valueOf(festivalId));
 		Boolean hasKey = redisTemplate.hasKey(redisKey);
 
 		if (!hasKey) {
@@ -46,5 +63,125 @@ public class ChatLocationService {
 		Long festivalId = getFestivalIdForRoom(roomId);	// roomId로 festivalId 조회
 		validateLocationToken(userId, festivalId);		// 토큰 유효성 검사 (거리 재계산 x)
 		log.debug("Location token validation success for user {}.", userId);
+	}
+
+	private String buildKey(String userId, String contextId) {
+		return "locationToken:" + userId + ":" + contextId;
+	}
+
+	private String buildLocationJson(String userId, String clientIp, String device, double lat, double lon) {
+		return String.format(
+			"{\"userId\":\"%s\",\"clientIp\":\"%s\",\"device\":\"%s\",\"lat\":%.6f,\"lon\":%.6f,\"timestamp\":%d}",
+			userId, clientIp, device, lat, lon, System.currentTimeMillis()
+		);
+	}
+
+	private String extractValue(String json, String field) {
+		String search = "\"" + field + "\":\"";
+		int start = json.indexOf(search);
+		if (start == -1)
+			return null;
+		start += search.length();
+		int end = json.indexOf("\"", start);
+		return json.substring(start, end);
+	}
+
+	// Redis에서 locationToken 정보 조회
+	private ChatUserLocationDto getLocationInfo(String userId, String contextId) {
+		String redisKey = buildKey(userId, contextId);
+		String saved = redisTemplate.opsForValue().get(redisKey);
+		if (saved == null)
+			return null;
+
+		try {
+			// ChatUserLocationDto는 apiserver의 UserTokenDto와 구조가 유사하나,
+			// chatserver의 DTO를 사용한다고 가정합니다.
+			return objectMapper.readValue(saved, ChatUserLocationDto.class);
+		} catch (JsonProcessingException e) {
+			log.error("Error reading location info from Redis for user {}: {}", userId, e.getMessage());
+			return null;
+		}
+	}
+
+	// locationToken 발행 (반경 무시)
+	private void generateLocationToken(String userId, String contextId, double lat, double lon) {
+		String redisKey = buildKey(userId, contextId);
+
+		try {
+			// clientIp와 device는 빈 문자열로 저장하여 JSON 구조 유지
+			String infoJson = buildLocationJson(userId, "", "", lat, lon);
+			redisTemplate.opsForValue().set(redisKey, infoJson, this.tokenTtl); // TTL 적용
+
+			log.debug("Generated location token for user {} in context {}.", userId, contextId);
+		} catch (Exception e) {
+			throw new RuntimeException("Redis 저장 중 오류 발생", e);
+		}
+	}
+
+	// 위치 + 디바이스 정보 업데이트 (TTL 갱신 포함)
+	private boolean updateLocationInfo(String userId, String contextId, double lat, double lon) {
+		String key = buildKey(userId, contextId);
+		String oldValue = redisTemplate.opsForValue().get(key);
+
+		if (oldValue == null) {
+			return false; // 토큰이 없으면 갱신 대신 생성
+		}
+
+		// 기존 정보 유지 + 좌표만 갱신
+		String clientIp = extractValue(oldValue, "clientIp");
+		String device = extractValue(oldValue, "device");
+
+		// null 체크하여 JSON 포맷 에러 방지
+		String finalClientIp = (clientIp == null) ? "" : clientIp;
+		String finalDevice = (device == null) ? "" : device;
+
+		String newValue = buildLocationJson(userId, finalClientIp, finalDevice, lat, lon);
+		redisTemplate.opsForValue().set(key, newValue, this.tokenTtl);
+
+		return true;
+	}
+
+	/**
+	 * STOMP /join 시 호출: 위치 인증 토큰을 설정하거나 갱신합니다. (반경 검사 수행)
+	 */
+	public void setLocationTokenOnJoin(String userId, String roomId, double lat, double lon) {
+		Long festivalId = getFestivalIdForRoom(roomId);
+		String contextId = String.valueOf(festivalId);
+
+		// PostGIS를 사용하여 거리를 계산합니다.
+		double distanceKm = festivalRepository.findDistanceToFestival(festivalId, lon, lat)
+			.orElse(Double.MAX_VALUE); // 축제 정보 없으면 MAX_VALUE로 처리하여 반경 밖으로 간주
+
+		if (distanceKm > max_radius) {
+			// 1. 반경을 벗어난 경우: 토큰 발급/갱신을 하지 않고, 예외 없이 함수를 종료합니다.
+			log.warn("User {} is outside the radius ({}km) for room {}. Location token is NOT issued/updated. (Joining allowed)",
+				userId, distanceKm, roomId);
+			return; // 토큰 발급 로직만 건너뛰고 정상 종료
+		}
+
+		// 2. 반경 내에 있을 경우: 토큰 갱신 또는 발급을 진행합니다.
+		// 2-1. 토큰이 유효하게 존재하는지 확인하고, 존재하면 위치 갱신 (TTL 갱신)
+		boolean updated = updateLocationInfo(userId, contextId, lat, lon);
+		if (!updated) {
+			// 2-2. 토큰이 존재하지 않으면 새로 생성
+			generateLocationToken(userId, contextId, lat, lon);
+		}
+
+		log.info("Location token set/updated on join for user {} in room {}. Within radius check passed.", userId, roomId);
+	}
+
+	/**
+	 * 사용자가 축제 반경 내에 있는지 PostGIS를 이용해 검증합니다.
+	 * (API Server의 FestivalInfoService 로직과 동일)
+	 */
+	private void checkUserWithinRadius(Long festivalId, double lat, double lon) {
+		double distanceKm = festivalRepository.findDistanceToFestival(festivalId, lon, lat)
+			.orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "축제 위치 정보를 찾을 수 없습니다."));
+
+		if (distanceKm > max_radius) {
+			// 반경을 벗어났다면 예외 발생
+			throw new BusinessException(ErrorCode.BAD_REQUEST,
+				"채팅방 입장은 반경(" + max_radius + "km) 내에서만 가능합니다.");
+		}
 	}
 }

--- a/chat-server/src/main/java/com/grm3355/zonie/chatserver/service/ChatRoomService.java
+++ b/chat-server/src/main/java/com/grm3355/zonie/chatserver/service/ChatRoomService.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -35,7 +36,9 @@ public class ChatRoomService {
 	// Redis Key Prefix 정의 (재사용성 및 가독성 향상)
 	private static final String KEY_PARTICIPANTS = "chatroom:participants:"; // 실시간 참여자 (Set)
 	private static final String KEY_USER_ROOMS = "user:rooms:"; // 유저별 참여방 (Set)
-	private static final long MAX_PARTICIPANTS = 300;
+
+	@Value("${chat.max-chat-person}")
+	private long MAX_PARTICIPANTS = 300;
 
 	private static final String NICKNAME_PREFIX = "#";
 

--- a/chat-server/src/test/java/com/grm3355/zonie/chatserver/ChatServerApplicationTests.java
+++ b/chat-server/src/test/java/com/grm3355/zonie/chatserver/ChatServerApplicationTests.java
@@ -2,13 +2,19 @@ package com.grm3355.zonie.chatserver;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.grm3355.zonie.chatserver.util.JwtChannelInterceptor;
 import com.grm3355.zonie.commonlib.global.util.JwtTokenProvider;
 
 @SpringBootTest
-class ChatServerApplicationTests extends BaseIntegrationTest {
+@TestPropertySource(properties = {
+	"location.token.ttl-minutes=15",
+	"chat.radius=1.0",
+	"chat.max-chat-person=300"
+})
+public class ChatServerApplicationTests extends BaseIntegrationTest {
 
 	@MockitoBean
 	private JwtChannelInterceptor jwtChannelInterceptor;

--- a/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/chatroom/entity/ChatRoom.java
+++ b/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/chatroom/entity/ChatRoom.java
@@ -59,7 +59,7 @@ public class ChatRoom extends BaseTimeEntity {
 	private String coverImageUrl;
 
 	@Column(name = "max_participants", nullable = false)
-	private int maxParticipants;
+	private Long maxParticipants;
 
 	@Column(name = "radius", nullable = false)
 	private double radius;


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: #40
- 서브 이슈: Resolved: #46

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- 지난번 PR#55에서 다뤘던 위치 토큰 개선 작업을 실제 로직에 반영함.
- 채팅방 생성 시:
  - 사용자 위치 정보를 Request Body(`ChatRoomRequest`)에 포함하여 요청하도록 변경함.
  - `ChatRoomService.setCreateChatRoom`에서 PostGIS 기반 반경 검증(`isUserWithinFestivalRadius`)을 수행하며, 반경 밖일 경우 `BusinessException`을 발생시켜 **생성 자체를 거부**함.
  - 반경 검증 통과 후 위치 토큰(`redisTokenService.setToken`)을 발급/갱신함.
- 채팅방 입장 시 (WebSocket /join):
  - **입장은 위치 인증 여부와 관계없이 자유롭게 허용**하도록 로직을 변경함.
  - `ChatLocationService.setLocationTokenOnJoin`을 호출하여 사용자 위치를 체크함.
  - **반경 내일 경우에만** 위치 인증 토큰을 발급/갱신하고, 반경 밖일 경우 **예외 없이 토큰 발급/갱신을 건너뜀** (`return`).
  - 실제 메시지 전송(`send`) 시에만 위치 인증 토큰의 유효성(`validateChatRoomEntry`)을 검사하여 행위를 제한함.
- 테스트 코드 반영

## 변경 이유
> 왜 이 변경이 필요한지 설명
- 위치 검증 로직을 기획에 맞게 수정함

## 테스트
> 어떤 방법으로 검증했는지 작성
- 유닛 테스트

## 참고 자료 (선택)
- 

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
-

## PR 체크리스트 
> 모두 했는지 확인 후 PR
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [x] API 문서 반영 완료