### PR TITLE
[#86] fix: CD before 커밋을 정상적으로 찾지 못하는 문제

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2 # 변경 사항 비교를 위해 최소 2개 커밋 가져오기
+          fetch-depth: 0 # 변경 사항 비교를 위해 최소 2개 커밋 가져오기
           ref: ${{ github.event.workflow_run.head_sha }} # push 이벤트 말고 CI를 실행시킨 커밋을 기준으로 checkout
 
       - name: Check for changed files


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: 
- 서브 이슈: #86 
- Resolved: #

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- CD fetch-depth 0으로 수정

## 변경 이유
> 왜 이 변경이 필요한지 설명
- paths-filter 실행 시 base로 지정된 before 커밋을 찾으려고 시도하지만 fetch-depth: 2고 너무 오래된 커밋이라서 찾을 수 없게 됨
- 기본값인 main 브랜치와 비교를 시도하게 되고 변경 감지를 못하게 됨

## 테스트
> 어떤 방법으로 검증했는지 작성
-

## 참고 자료 (선택)
- main 브랜치의 최신 커밋(HEAD)동일: `github.event.workflow_run.head_sha (2fb0d7c...)`
- 결과: `Detected 0 changed files`

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
-

## PR 체크리스트 
> 모두 했는지 확인 후 PR
-