### PR TITLE
[#144] fix: 내 채팅방 목록 응답에 실시간 Redis 데이터 적용

### DIFF
--- a/api-server/src/test/java/com/grm3355/zonie/apiserver/domain/chatroom/ChatRoomControllerTest.java
+++ b/api-server/src/test/java/com/grm3355/zonie/apiserver/domain/chatroom/ChatRoomControllerTest.java
@@ -112,6 +112,8 @@ class ChatRoomControllerTest extends BaseIntegrationTest {
 			.title("내 채팅방")
 			.participantCount(5L)
 			.festivalTitle("테스트 축제")
+			.lastMessageAt(1636886400000L)
+			.lastContent("안녕하세요")
 			.build();
 
 		// Page 객체로 반환값 세팅
@@ -133,6 +135,8 @@ class ChatRoomControllerTest extends BaseIntegrationTest {
 			.andExpect(jsonPath("$.data.content[0].chatRoomId").value(1L))
 			.andExpect(jsonPath("$.data.content[0].title").value("내 채팅방"))
 			.andExpect(jsonPath("$.data.content[0].participantCount").value(5))
-			.andExpect(jsonPath("$.data.content[0].festivalTitle").value("테스트 축제"));
+			.andExpect(jsonPath("$.data.content[0].festivalTitle").value("테스트 축제"))
+			.andExpect(jsonPath("$.data.content[0].lastMessageAt").value(1636886400000L))
+			.andExpect(jsonPath("$.data.content[0].lastContent").value("안녕하세요"));
 	}
 }


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: #75
- 서브 이슈: #76, Resolved: #144

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- 내 채팅방 목록 조회 API (GET /api/v1/chat-rooms/my-rooms) 응답에서 실시간 데이터(참여자 수, 마지막 대화 시각/내용)를 PostgreSQL 데이터와 병합하는 로직이 없어 해당 필드가 null로 반환되던 문제를 해결했습니다.
- 주요 변경 사항:
1. `getFestivalChatRoomList`에 있던 Redis 실시간 데이터 조회 및 병합 로직을 `mergeChatRoomDataWithRedis(Page<ChatRoomInfoDto> pageList, Pageable pageable)`라는 공통 private 메서드로 추출했습니다.
2. `getFestivalChatRoomList`와 `getMyRoomChatRoomList` 모두에서 이 공통 메서드를 사용하도록 수정했습니다.
3. 사용되지 않는 `ChatRoomService`의 `getLastContents` 메서드에 @Deprecated 어노테이션을 추가했습니다.

## 변경 이유
> 왜 이 변경이 필요한지 설명
- '내 채팅방 목록'도 '축제별 채팅방 목록'과 동일하게 정확한 실시간 참여자 수 및 메시지 상세 정보를 제공합니다.

## 테스트
> 어떤 방법으로 검증했는지 작성
- 유닛 테스트 수정 (실시간 데이터 추가)

## 참고 자료 (선택)
- 

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
-

## PR 체크리스트 
> 모두 했는지 확인 후 PR
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [x] API 문서 반영 완료