### PR TITLE
[#170] hotfix: api-server cpu 리소스 다시 복구

### DIFF
--- a/.ecs/task-definition-api.json
+++ b/.ecs/task-definition-api.json
@@ -5,7 +5,7 @@
   "requiresCompatibilities": [
     "FARGATE"
   ],
-  "cpu": "256",
+  "cpu": "512",
   "memory": "1024",
   "containerDefinitions": [
     {


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: #169
- 서브 이슈: Resolved: #170 

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- 모니터링 결과 512로 충분할 것으로 예상되고, 비용 줄이는 목적으로 cpu 리소스를 256MB로 줄였었는데, 다시 512로 복구함

## 변경 이유
> 왜 이 변경이 필요한지 설명
- 모니터링 다시 체크해보니 여유있게 리소스 배정하는게 나을 것 같다는 판단.