### PR TITLE
[#186] fix: 배치 서버 채팅방 삭제 및 카운트 불일치 문제 해결

### DIFF
--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/chatroom/service/ChatRoomApiService.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/chatroom/service/ChatRoomApiService.java
@@ -490,8 +490,14 @@ public class ChatRoomApiService {
 
 		// 5. ChatRoom.memberCount--
 		if (room.getMemberCount() > 0) {
-			room.setMemberCount(room.getMemberCount() - 1);
+			long newCount = room.getMemberCount() - 1;
+			room.setMemberCount(newCount);
 			chatRoomRepository.save(room); // Dirty Checking | 명시적 save
+
+			if (newCount == 0 && room.getFestival() != null) {
+				Long festivalId = room.getFestival().getFestivalId();
+				festivalRepository.decrementFestivalChatRoomCount(festivalId);
+			}
 		}
 
 		// 6. Redis Pub/Sub 이벤트 발행 (Chat Server로 실시간 연결 알림)

--- a/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/chatroom/repository/ChatRoomRepository.java
+++ b/common-lib/src/main/java/com/grm3355/zonie/commonlib/domain/chatroom/repository/ChatRoomRepository.java
@@ -205,6 +205,13 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 	List<String> findEmptyRoomIds(@Param("graceTime") LocalDateTime graceTime);
 
 	/**
+	 * 주어진 채팅방 ID 목록에 연결된 유효한 축제 ID를 중복 없이 조회
+	 * (채팅방 삭제 전, 영향을 받는 Festival을 파악하기 위해 사용)
+	 */
+	@Query(value = "SELECT DISTINCT c.festival_id FROM chat_rooms c WHERE c.chat_room_id IN :roomIds AND c.festival_id IS NOT NULL", nativeQuery = true)
+	List<Long> findFestivalIdsByRoomIds(@Param("roomIds") List<String> roomIds);
+
+	/**
 	 * 3. 축제가 종료된 채팅방 삭제
 	 * 조건: ChatRoom과 연결된 Festival의 eventEndDate가 오늘 이전인 경우
 	 * JPQL은 연관 관계를 타고 삭제할 수 없으므로, 서브쿼리나 ID 리스트를 사용해야 함.


### PR DESCRIPTION
> 제목은 `[#Issue-Number] type: 설명`의 형식으로 작성해주세요.

## 관련 이슈
- 메인 이슈: #182 
- 서브 이슈:
- Resolved:  #186

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- 채팅방 삭제 후 festivals.chat_room_count가 불일치하는 문제 해결을 위해 재집계 로직 추가
- leave api 요청 시에도 chat_room_count 체크하는 로직 추가