### PR TITLE
[#166] fix: JVM GC 로그 오류 해결

### DIFF
--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -10,4 +10,4 @@ COPY api-server/build/libs/api-server-*.jar app.jar
 EXPOSE 8080
 
 # 컨테이너 시작 시 실행할 명령어
-ENTRYPOINT ["java", "-Xms2g", "-Xmx2g", "-Xlog:gc*:file=/app/logs/gc.log:time,level,tags", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xms2g", "-Xmx2g", "-Xlog:gc*:stdout:time,level,tags", "-jar", "app.jar"]

--- a/batch-server/Dockerfile
+++ b/batch-server/Dockerfile
@@ -11,4 +11,4 @@ COPY batch-server/build/libs/batch-server-*.jar app.jar
 
 # 컨테이너 시작 시 실행할 명령어
 # 배치 서버는 대용량 데이터 처리 시 OOM 위험이 있어서 4기가로 설정함
-ENTRYPOINT ["java", "-Xms4g", "-Xmx4g", "-Xlog:gc*:file=/app/logs/gc.log:time,level,tags", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xms4g", "-Xmx4g", "-Xlog:gc*:stdout:time,level,tags", "-jar", "app.jar"]

--- a/chat-server/Dockerfile
+++ b/chat-server/Dockerfile
@@ -12,4 +12,4 @@ EXPOSE 8081
 
 # 컨테이너 시작 시 실행할 명령어
 # 챗 서버는 동시 연결 수가 많을 수록 메모리 사용량이 증가하기 때문에, 우선 4기가로 설정해 부하 대비함
-ENTRYPOINT ["java", "-Xms4g", "-Xmx4g", "-Xlog:gc*:file=/app/logs/gc.log:time,level,tags", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xms4g", "-Xmx4g", "-Xlog:gc*:stdout:time,level,tags", "-jar", "app.jar"]


### PR DESCRIPTION
로그 파일 경로를 컨테이너가 접근 가능한 stdout/err 스트림으로 변경