### PR TITLE
[#166] chore: ecs task definition api-server cpu 리소스 상향

### DIFF
--- a/.ecs/task-definition-api.json
+++ b/.ecs/task-definition-api.json
@@ -5,8 +5,8 @@
   "requiresCompatibilities": [
     "FARGATE"
   ],
-  "cpu": "1024",
-  "memory": "3072",
+  "cpu": "2048",
+  "memory": "4096",
   "containerDefinitions": [
     {
       "name": "zonie-api-server",


### PR DESCRIPTION
- 부하테스트 과정에서 cpu throttling 발생
- 2 vCPU (2048 units)로 상향
- [fargate 리소스 사전정의](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size)