### PR TITLE
[#208] fix: AESUtil 수정에 따른 기존 데이터 마이그레이션 - 오류 수정

### DIFF
--- a/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/user/service/UserMigrationService.java
+++ b/api-server/src/main/java/com/grm3355/zonie/apiserver/domain/user/service/UserMigrationService.java
@@ -37,9 +37,9 @@ public class UserMigrationService {
 		for (User user : users) {
 			String encryptedEmail = user.getAccountEmail();
 
-			// 2. 이미 신 버전으로 암호화되었거나, 이메일이 없는 경우 스킵
-			//    (신 버전 암호화는 복잡도가 높고 길이가 길어 구버전과 구별 가능해야 함)
-			if (encryptedEmail == null || encryptedEmail.length() > 50) { // 길이 기반의 임시 구분
+			// 2. 이미 신 버전으로 암호화되었거나, 이메일이 유효하지 않은 스킵
+			if (encryptedEmail == null || encryptedEmail.trim().isEmpty() || encryptedEmail.length() < 10
+				|| encryptedEmail.length() > 50) {
 				continue;
 			}
 
@@ -64,6 +64,9 @@ public class UserMigrationService {
 		}
 
 		log.warn("=== [SECURITY] MIGRATION COMPLETED: {} users updated ===", migratedCount);
+
 		return migratedCount;
+
 	}
+
 }


### PR DESCRIPTION
decryptEcb: keyString을 Base64 디코딩 없이 직접 바이트로 변환하는 기존 로직을 정확하게 재현