### PR TITLE
[#166] chore: DB 커넥션 풀 크기 임시로 증설 -> 취소

### DIFF
--- a/api-server/src/main/resources/application.yml
+++ b/api-server/src/main/resources/application.yml
@@ -9,6 +9,10 @@ spring:
     group:
       "dev": "dev,local"
       "prod": "prod"
+  datasource:
+    hikari:
+      maximum-pool-size: 5  # 최대 커넥션 수
+      connection-timeout: 60000  # 커넥션을 얻기 위해 대기하는 시간: 60초
 management:
   endpoints:
     web:


### PR DESCRIPTION
spring.datasource.hikari.
- maximum-pool-size: 50 (최대 커넥션 수)
- connection-timeout: 60000 (커넥션 연결 대기 시간)

-> 커넥션 풀 문제 원인 아닌 것으로 판단됨 -> 취소